### PR TITLE
[Sponsor] 후원사 이미지 클릭 시 브라우저로 홈페이지 연결

### DIFF
--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -3,6 +3,7 @@ package com.droidknights.app2023.feature.home
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -112,18 +114,25 @@ private fun SponsorLogo(
     sponsor: Sponsor,
     onClick: () -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     val gradeIcon = when (sponsor.grade) {
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
         Sponsor.Grade.PLATINUM -> R.drawable.ic_crown_platinum
     }
-    Box {
+    Box(
+        modifier = Modifier
+            .clickable(
+                onClick = onClick,
+                interactionSource = interactionSource,
+                indication = null
+            )
+    ) {
         NetworkImage(
             imageUrl = sponsor.imageUrl,
             placeholder = ColorPainter(PaleGray),
             modifier = Modifier
                 .size(84.dp)
                 .clip(CircleShape)
-                .clickable(onClick = onClick)
         )
         Image(
             painter = painterResource(id = gradeIcon),
@@ -134,6 +143,7 @@ private fun SponsorLogo(
         )
     }
 }
+
 
 @Preview
 @Composable

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -3,7 +3,6 @@ package com.droidknights.app2023.feature.home
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,7 +16,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -114,25 +112,18 @@ private fun SponsorLogo(
     sponsor: Sponsor,
     onClick: () -> Unit
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
     val gradeIcon = when (sponsor.grade) {
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
         Sponsor.Grade.PLATINUM -> R.drawable.ic_crown_platinum
     }
-    Box(
-        modifier = Modifier
-            .clickable(
-                onClick = onClick,
-                interactionSource = interactionSource,
-                indication = null
-            )
-    ) {
+    Box {
         NetworkImage(
             imageUrl = sponsor.imageUrl,
             placeholder = ColorPainter(PaleGray),
             modifier = Modifier
                 .size(84.dp)
                 .clip(CircleShape)
+                .clickable(onClick = onClick)
         )
         Image(
             painter = painterResource(id = gradeIcon),
@@ -143,7 +134,6 @@ private fun SponsorLogo(
         )
     }
 }
-
 
 @Preview
 @Composable

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -123,7 +123,7 @@ private fun SponsorLogo(
             modifier = Modifier
                 .size(84.dp)
                 .clip(CircleShape)
-                .clickable { onClick() }
+                .clickable(onClick = onClick)
         )
         Image(
             painter = painterResource(id = gradeIcon),

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -1,6 +1,7 @@
 package com.droidknights.app2023.feature.home
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.UriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -74,6 +77,7 @@ private fun SponsorGroup(
 ) {
     val scrollState = rememberLazyListState()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val uriHandler = LocalUriHandler.current
 
     LazyRow(
         state = scrollState,
@@ -87,7 +91,11 @@ private fun SponsorGroup(
             .fillMaxWidth(),
     ) {
         items(count = Int.MAX_VALUE) { index ->
-            SponsorLogo(sponsor = sponsors[index % sponsors.size])
+            val sponsor = sponsors[index % sponsors.size]
+            SponsorLogo(
+                sponsor = sponsor,
+                onClick = { uriHandler.openUri(sponsor.homepage) }
+            )
         }
     }
     LaunchedEffect(Unit) {
@@ -103,6 +111,7 @@ private fun SponsorGroup(
 @Composable
 private fun SponsorLogo(
     sponsor: Sponsor,
+    onClick: () -> Unit
 ) {
     val gradeIcon = when (sponsor.grade) {
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
@@ -115,6 +124,7 @@ private fun SponsorLogo(
             modifier = Modifier
                 .size(84.dp)
                 .clip(CircleShape)
+                .clickable { onClick() }
         )
         Image(
             painter = painterResource(id = gradeIcon),


### PR DESCRIPTION
## Issue
- close #182 

## Overview (Required)
- 후원사 이미지를 클릭하면 `Sponsor` 모델에 정의된 URL에 브라우저로 연결된다.
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/72238126/d981e06a-0d1f-4bef-992b-40e0c6af02e3" width="300" />
