### PR TITLE
[Home] 후원사 카드 내부 로고 배치 수정 

### DIFF
--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -1,7 +1,6 @@
 package com.droidknights.app2023.feature.home
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -9,34 +8,26 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.repeatOnLifecycle
 import com.droidknights.app2023.core.designsystem.component.KnightsCard
 import com.droidknights.app2023.core.designsystem.component.NetworkImage
 import com.droidknights.app2023.core.designsystem.theme.DuskGray
 import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
 import com.droidknights.app2023.core.designsystem.theme.PaleGray
 import com.droidknights.app2023.core.model.Sponsor
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-
-private const val SCROLL_DELAY_MILLIS = 20L
-private const val SCROLL_PIXEL_UNIT = 4f
 
 @Composable
 internal fun SponsorCard(uiState: SponsorsUiState) {
@@ -67,35 +58,56 @@ internal fun SponsorCard(uiState: SponsorsUiState) {
     }
 }
 
-// TODO: 세로 두 줄 고정 필요
 @Composable
 private fun SponsorGroup(
     sponsors: List<Sponsor>,
 ) {
-    val scrollState = rememberLazyListState()
-    val lifecycleOwner = LocalLifecycleOwner.current
+    val platinumSponsors = sponsors.filter { it.grade == Sponsor.Grade.PLATINUM }
+    val goldSponsors = sponsors.filter { it.grade == Sponsor.Grade.GOLD }
 
-    LazyRow(
-        state = scrollState,
-        horizontalArrangement = Arrangement.spacedBy(
-            space = 14.dp,
-            alignment = Alignment.CenterHorizontally,
-        ),
-        userScrollEnabled = false,
+    Column(
         modifier = Modifier
+            .fillMaxWidth()
             .padding(vertical = 24.dp)
-            .fillMaxWidth(),
     ) {
-        items(count = Int.MAX_VALUE) { index ->
-            SponsorLogo(sponsor = sponsors[index % sponsors.size])
-        }
+        SponsorGroupRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 21.dp,
+                    end = 24.dp
+                ),
+            sponsors = platinumSponsors
+        )
+
+        SponsorGroupRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = 69.dp,
+                    end = 24.dp
+                ),
+            sponsors = goldSponsors
+        )
     }
-    LaunchedEffect(Unit) {
-        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            while (isActive) {
-                scrollState.scrollBy(SCROLL_PIXEL_UNIT)
-                delay(SCROLL_DELAY_MILLIS)
+}
+
+@Composable
+private fun SponsorGroupRow(
+    modifier: Modifier = Modifier,
+    sponsors: List<Sponsor>
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(space = 11.dp),
+    ) {
+        items(
+            items = sponsors,
+            key = { sponsor ->
+                sponsor.name
             }
+        ) { sponsor ->
+            SponsorLogo(sponsor = sponsor)
         }
     }
 }
@@ -108,11 +120,15 @@ private fun SponsorLogo(
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
         Sponsor.Grade.PLATINUM -> R.drawable.ic_crown_platinum
     }
-    Box {
+    Box(modifier = Modifier.padding(start = 3.dp)) {
         NetworkImage(
             imageUrl = sponsor.imageUrl,
             placeholder = ColorPainter(PaleGray),
             modifier = Modifier
+                .shadow(
+                    elevation = 3.dp,
+                    shape = CircleShape
+                )
                 .size(84.dp)
                 .clip(CircleShape)
         )

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -75,25 +76,20 @@ private fun SponsorGroup(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 24.dp)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         SponsorGroupRow(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 21.dp,
-                    end = 24.dp
-                ),
+                .wrapContentWidth()
+                .padding(end = 36.dp),
             sponsors = platinumSponsorsState
         )
 
         SponsorGroupRow(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 69.dp,
-                    end = 24.dp
-                ),
+                .wrapContentWidth()
+                .padding(start = 36.dp),
             sponsors = goldSponsorsState
         )
     }
@@ -108,7 +104,8 @@ private fun SponsorGroupRow(
 
     LazyRow(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(space = 11.dp),
+        horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
+        userScrollEnabled = false
     ) {
         items(
             items = sponsors,
@@ -133,7 +130,7 @@ private fun SponsorLogo(
         Sponsor.Grade.GOLD -> R.drawable.ic_crown_gold
         Sponsor.Grade.PLATINUM -> R.drawable.ic_crown_platinum
     }
-    Box(modifier = Modifier.padding(start = 3.dp)) {
+    Box(modifier = Modifier.padding(3.dp)) {
         NetworkImage(
             imageUrl = sponsor.imageUrl,
             placeholder = ColorPainter(PaleGray),
@@ -171,9 +168,21 @@ private fun SponsorCardPreview() {
                 Sponsor(
                     name = "Sponsor2",
                     homepage = "https://www.instagram.com/droid_knights",
+                    grade = Sponsor.Grade.GOLD,
+                    imageUrl = "https://avatars.githubusercontent.com/u/25101514",
+                ),
+                Sponsor(
+                    name = "Sponsor3",
+                    homepage = "https://www.instagram.com/droid_knights",
                     grade = Sponsor.Grade.PLATINUM,
                     imageUrl = "https://avatars.githubusercontent.com/u/25101514",
                 ),
+                Sponsor(
+                    name = "Sponsor4",
+                    homepage = "https://www.instagram.com/droid_knights",
+                    grade = Sponsor.Grade.PLATINUM,
+                    imageUrl = "https://avatars.githubusercontent.com/u/25101514",
+                )
             ).let(::SponsorsUiState)
         )
     }

--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/SponsorCard.kt
@@ -2,7 +2,6 @@ package com.droidknights.app2023.feature.home
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,12 +14,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.painter.ColorPainter
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -69,6 +69,9 @@ private fun SponsorGroup(
     val platinumSponsors = sponsors.filter { it.grade == Sponsor.Grade.PLATINUM }
     val goldSponsors = sponsors.filter { it.grade == Sponsor.Grade.GOLD }
 
+    val platinumSponsorsState by rememberUpdatedState(platinumSponsors)
+    val goldSponsorsState by rememberUpdatedState(goldSponsors)
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -81,7 +84,7 @@ private fun SponsorGroup(
                     start = 21.dp,
                     end = 24.dp
                 ),
-            sponsors = platinumSponsors
+            sponsors = platinumSponsorsState
         )
 
         SponsorGroupRow(
@@ -91,7 +94,7 @@ private fun SponsorGroup(
                     start = 69.dp,
                     end = 24.dp
                 ),
-            sponsors = goldSponsors
+            sponsors = goldSponsorsState
         )
     }
 }


### PR DESCRIPTION
## Issue
- close #161 

## Overview (Required)
- 기존 후원사 카드 내부 로고 배치 수정
- 자동/무한 스크롤 기능 제거
    - 이 기능은 더 이상 유효하지 않으므로 제거합니다.

## Screenshot
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/61337202/ed792b4e-9a3d-432b-8078-2253a02c3589" width="300" /> 
