### PR TITLE
[Bug] 각 탭에서 스크롤이 되지않습니다

### DIFF
--- a/feature/home/src/main/java/com/droidknights/app2023/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/droidknights/app2023/feature/home/HomeScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -35,10 +37,12 @@ private fun HomeScreen(
     onSessionClick: () -> Unit,
     onContributorClick: () -> Unit,
 ) {
+    val scrollState = rememberScrollState()
     Column(
         Modifier
             .padding(padding)
-            .padding(horizontal = 8.dp),
+            .padding(horizontal = 8.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         SessionCard(onClick = onSessionClick)

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -45,12 +47,14 @@ internal fun SessionDetailScreen(
     onBackClick: () -> Unit,
     viewModel: SessionDetailViewModel = hiltViewModel(),
 ) {
+    val scrollState = rememberScrollState()
     val sessionUiState by viewModel.sessionUiState.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surfaceDim)
-            .systemBarsPadding(),
+            .systemBarsPadding()
+            .verticalScroll(scrollState),
     ) {
         SessionDetailTopAppBar(onBackClick = onBackClick)
         SessionDetailContent(uiState = sessionUiState)

--- a/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
@@ -34,10 +36,12 @@ import com.droidknights.app2023.core.designsystem.theme.LocalDarkTheme
 
 @Composable
 internal fun SettingScreen(padding: PaddingValues) {
+    val scrollState = rememberScrollState()
     Column(
         Modifier
             .padding(padding)
-            .padding(8.dp),
+            .padding(8.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         LightDarkThemeCard()


### PR DESCRIPTION
## Issue
- close #162
- close #165 
=> 레이아웃 깨짐의 원인이 scrollState 의 부재였던 것 같습니다

## Overview (Required)
- 각 탭에 vertcalScroll 에 scrollState 값 추가

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/18674395/1a128282-8f57-4c70-9800-6f3010c0239e" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/18674395/4000d7e7-69d6-42f7-8424-2b581a39ba80" width="300" />
