### PR TITLE
[Session] 세션 상세정보 화면 디자인 변경

### DIFF
--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionCard.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionCard.kt
@@ -33,6 +33,7 @@ import com.droidknights.app2023.core.model.Session
 import com.droidknights.app2023.core.model.Speaker
 import com.droidknights.app2023.core.model.Tag
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDateTime
 
 @Composable
 internal fun SessionCard(
@@ -87,7 +88,11 @@ private fun SessionCardContent(
 
         // 트랙
         Spacer(modifier = Modifier.height(12.dp))
-        SessionChips(session = session)
+        Row {
+            TrackChip(room = session.room)
+            Spacer(modifier = Modifier.width(8.dp))
+            TimeChip(time = session.startTime.toJavaLocalDateTime().toLocalTime())
+        }
 
         // 발표자
         Spacer(modifier = Modifier.height(12.dp))

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionCard.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionCard.kt
@@ -33,7 +33,6 @@ import com.droidknights.app2023.core.model.Session
 import com.droidknights.app2023.core.model.Speaker
 import com.droidknights.app2023.core.model.Tag
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.toJavaLocalDateTime
 
 @Composable
 internal fun SessionCard(
@@ -91,7 +90,7 @@ private fun SessionCardContent(
         Row {
             TrackChip(room = session.room)
             Spacer(modifier = Modifier.width(8.dp))
-            TimeChip(time = session.startTime.toJavaLocalDateTime().toLocalTime())
+            TimeChip(dateTime = session.startTime)
         }
 
         // 발표자

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionChip.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionChip.kt
@@ -7,7 +7,8 @@ import androidx.compose.ui.res.stringResource
 import com.droidknights.app2023.core.designsystem.component.TextChip
 import com.droidknights.app2023.core.model.Room
 import com.droidknights.app2023.core.ui.textRes
-import java.time.LocalTime
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
@@ -20,9 +21,11 @@ internal fun TrackChip(room: Room) {
 }
 
 @Composable
-internal fun TimeChip(time: LocalTime) {
+internal fun TimeChip(dateTime: LocalDateTime) {
     val pattern = stringResource(id = R.string.session_time_fmt)
     val formatter = remember { DateTimeFormatter.ofPattern(pattern) }
+    val time = remember { dateTime.toJavaLocalDateTime().toLocalTime() }
+
     TextChip(
         text = formatter.format(time),
         containerColor = MaterialTheme.colorScheme.tertiaryContainer,

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionChip.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionChip.kt
@@ -1,33 +1,17 @@
 package com.droidknights.app2023.feature.session
 
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.droidknights.app2023.core.designsystem.component.TextChip
 import com.droidknights.app2023.core.model.Room
-import com.droidknights.app2023.core.model.Session
 import com.droidknights.app2023.core.ui.textRes
-import kotlinx.datetime.toJavaLocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 @Composable
-internal fun SessionChips(session: Session) {
-    Row {
-        TrackChip(room = session.room)
-        Spacer(modifier = Modifier.width(8.dp))
-        TimeChip(session.startTime.toJavaLocalDateTime().toLocalTime())
-    }
-}
-
-@Composable
-private fun TrackChip(room: Room) {
+internal fun TrackChip(room: Room) {
     TextChip(
         text = stringResource(id = room.textRes),
         containerColor = MaterialTheme.colorScheme.secondaryContainer,
@@ -36,7 +20,7 @@ private fun TrackChip(room: Room) {
 }
 
 @Composable
-private fun TimeChip(time: LocalTime) {
+internal fun TimeChip(time: LocalTime) {
     val pattern = stringResource(id = R.string.session_time_fmt)
     val formatter = remember { DateTimeFormatter.ofPattern(pattern) }
     TextChip(

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -121,7 +121,7 @@ private fun SessionDetailContent(session: Session) {
         Divider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline)
         Spacer(modifier = Modifier.height(40.dp))
 
-        SessionDetailSpeaker(session.speakers.toPersistentList())
+        SessionDetailSpeaker(session.speakers.first())
     }
 }
 
@@ -168,40 +168,38 @@ private fun SessionDetailTitle(
 
 @Composable
 private fun SessionDetailSpeaker(
-    speakers: PersistentList<Speaker>,
+    speaker: Speaker,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        speakers.forEach { speaker ->
-            NetworkImage(
-                imageUrl = speaker.imageUrl,
-                modifier = Modifier
-                    .size(108.dp)
-                    .clip(CircleShape),
-                placeholder = painterResource(id = com.droidknights.app2023.core.ui.R.drawable.placeholder_speaker)
-            )
+        NetworkImage(
+            imageUrl = speaker.imageUrl,
+            modifier = Modifier
+                .size(108.dp)
+                .clip(CircleShape),
+            placeholder = painterResource(id = com.droidknights.app2023.core.ui.R.drawable.placeholder_speaker)
+        )
 
-            Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(16.dp))
 
-            Text(
-                text = stringResource(id = R.string.session_detail_speaker),
-                style = KnightsTheme.typography.labelSmallM,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
-            Text(
-                text = speaker.name,
-                style = KnightsTheme.typography.titleMediumB,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
+        Text(
+            text = stringResource(id = R.string.session_detail_speaker),
+            style = KnightsTheme.typography.labelSmallM,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+        Text(
+            text = speaker.name,
+            style = KnightsTheme.typography.titleMediumB,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
 
-            Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(16.dp))
 
-            Text(
-                text = speaker.introduction,
-                style = KnightsTheme.typography.titleSmallR140,
-                color = MaterialTheme.colorScheme.onSecondaryContainer,
-            )
-        }
+        Text(
+            text = speaker.introduction,
+            style = KnightsTheme.typography.titleSmallR140,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
     }
 }
 
@@ -224,11 +222,6 @@ private val SampleSessionHasContent = Session(
             introduction = "스피커1 에 대한 소개",
             imageUrl = "",
         ),
-        Speaker(
-            name = "스피커2",
-            introduction = "스피커2 에 대한 소개",
-            imageUrl = "",
-        )
     ),
     level = Level.ADVANCED,
     tags = listOf(Tag("Dev Environment")),
@@ -247,11 +240,6 @@ private val SampleSessionNoContent = Session(
             introduction = "스피커1 에 대한 소개",
             imageUrl = "",
         ),
-        Speaker(
-            name = "스피커2",
-            introduction = "스피커2 에 대한 소개",
-            imageUrl = "",
-        )
     ),
     level = Level.ADVANCED,
     tags = listOf(Tag("Dev Environment")),
@@ -297,7 +285,7 @@ private fun SessionDetailTitlePreview() {
 @Composable
 private fun SessionDetailSpeakerPreview() {
     KnightsTheme {
-        SessionDetailSpeaker(SampleSessionHasContent.speakers.toPersistentList())
+        SessionDetailSpeaker(SampleSessionHasContent.speakers.first())
     }
 }
 

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -138,7 +138,7 @@ private fun SessionChips(session: Session) {
 }
 
 @Composable
-private fun TagChips(tags: List<Tag>) {
+private fun TagChips(tags: PersistentList<Tag>) {
     tags.forEach { tag ->
         TagChip(tag = tag)
     }

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -226,12 +226,12 @@ private val SampleSessionHasContent = Session(
         Speaker(
             name = "스피커1",
             introduction = "스피커1 에 대한 소개",
-            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+            imageUrl = "",
         ),
         Speaker(
             name = "스피커2",
             introduction = "스피커2 에 대한 소개",
-            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+            imageUrl = "",
         )
     ),
     level = Level.ADVANCED,
@@ -249,12 +249,12 @@ private val SampleSessionNoContent = Session(
         Speaker(
             name = "스피커1",
             introduction = "스피커1 에 대한 소개",
-            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+            imageUrl = "",
         ),
         Speaker(
             name = "스피커2",
             introduction = "스피커2 에 대한 소개",
-            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+            imageUrl = "",
         )
     ),
     level = Level.ADVANCED,

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -48,7 +48,6 @@ import com.droidknights.app2023.core.model.Tag
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.toJavaLocalDateTime
 
 @Composable
 internal fun SessionDetailScreen(
@@ -131,7 +130,7 @@ private fun SessionChips(session: Session) {
     Row {
         TrackChip(room = session.room)
         Spacer(modifier = Modifier.width(8.dp))
-        TimeChip(time = session.startTime.toJavaLocalDateTime().toLocalTime())
+        TimeChip(dateTime = session.startTime)
         Spacer(modifier = Modifier.width(8.dp))
         TagChips(tags = session.tags.toPersistentList())
     }

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.droidknights.app2023.feature.session
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
@@ -127,22 +127,19 @@ private fun SessionDetailContent(session: Session) {
 
 @Composable
 private fun SessionChips(session: Session) {
-    Row {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         TrackChip(room = session.room)
-        Spacer(modifier = Modifier.width(8.dp))
         TimeChip(dateTime = session.startTime)
-        Spacer(modifier = Modifier.width(8.dp))
         TagChips(tags = session.tags.toPersistentList())
     }
 }
 
 @Composable
 private fun TagChips(tags: List<Tag>) {
-    tags.forEachIndexed { index, tag ->
-        if (index != 0) {
-            Spacer(modifier = Modifier.width(8.dp))
-        }
-
+    tags.forEach { tag ->
         TagChip(tag = tag)
     }
 }

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -3,12 +3,14 @@ package com.droidknights.app2023.feature.session
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
@@ -32,8 +34,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.droidknights.app2023.core.designsystem.component.KnightsTopAppBar
 import com.droidknights.app2023.core.designsystem.component.NetworkImage
+import com.droidknights.app2023.core.designsystem.component.TextChip
 import com.droidknights.app2023.core.designsystem.component.TopAppBarNavigationType
+import com.droidknights.app2023.core.designsystem.theme.DarkGray
 import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
+import com.droidknights.app2023.core.designsystem.theme.LightGray
 import com.droidknights.app2023.core.designsystem.theme.surfaceDim
 import com.droidknights.app2023.core.model.Level
 import com.droidknights.app2023.core.model.Room
@@ -43,6 +48,7 @@ import com.droidknights.app2023.core.model.Tag
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDateTime
 
 @Composable
 internal fun SessionDetailScreen(
@@ -118,6 +124,37 @@ private fun SessionDetailContent(session: Session) {
 
         SessionDetailSpeaker(session.speakers.toPersistentList())
     }
+}
+
+@Composable
+private fun SessionChips(session: Session) {
+    Row {
+        TrackChip(room = session.room)
+        Spacer(modifier = Modifier.width(8.dp))
+        TimeChip(time = session.startTime.toJavaLocalDateTime().toLocalTime())
+        Spacer(modifier = Modifier.width(8.dp))
+        TagChips(tags = session.tags.toPersistentList())
+    }
+}
+
+@Composable
+private fun TagChips(tags: List<Tag>) {
+    tags.forEachIndexed { index, tag ->
+        if (index != 0) {
+            Spacer(modifier = Modifier.width(8.dp))
+        }
+
+        TagChip(tag = tag)
+    }
+}
+
+@Composable
+private fun TagChip(tag: Tag) {
+    TextChip(
+        text = tag.name,
+        containerColor = DarkGray,
+        labelColor = LightGray,
+    )
 }
 
 @Composable

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -106,13 +107,15 @@ private fun SessionDetailContent(session: Session) {
         SessionDetailTitle(title = session.title, modifier = Modifier.padding(top = 8.dp))
         Spacer(modifier = Modifier.height(8.dp))
         SessionChips(session = session)
+
         if (session.content.isNotEmpty()) {
             Spacer(modifier = Modifier.height(16.dp))
             SessionOverview(content = session.content)
-            Spacer(modifier = Modifier.height(56.dp))
-        } else {
-            Spacer(modifier = Modifier.height(40.dp))
         }
+        Spacer(modifier = Modifier.height(40.dp))
+        Divider(thickness = 1.dp, color = MaterialTheme.colorScheme.outline)
+        Spacer(modifier = Modifier.height(40.dp))
+
         SessionDetailSpeaker(session.speakers.toPersistentList())
     }
 }
@@ -136,26 +139,36 @@ private fun SessionDetailSpeaker(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        Text(
-            text = stringResource(id = R.string.session_detail_speaker),
-            style = KnightsTheme.typography.labelSmallM,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
         speakers.forEach { speaker ->
+            NetworkImage(
+                imageUrl = speaker.imageUrl,
+                modifier = Modifier
+                    .size(108.dp)
+                    .clip(CircleShape),
+                placeholder = painterResource(id = com.droidknights.app2023.core.ui.R.drawable.placeholder_speaker)
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(id = R.string.session_detail_speaker),
+                style = KnightsTheme.typography.labelSmallM,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
             Text(
                 text = speaker.name,
                 style = KnightsTheme.typography.titleMediumB,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            Text(
+                text = speaker.introduction,
+                style = KnightsTheme.typography.titleSmallR140,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
             )
         }
-        Spacer(Modifier.height(8.dp))
-        NetworkImage(
-            imageUrl = speakers.firstOrNull()?.imageUrl ?: "",
-            modifier = Modifier
-                .size(108.dp)
-                .clip(CircleShape),
-            placeholder = painterResource(id = com.droidknights.app2023.core.ui.R.drawable.placeholder_speaker)
-        )
     }
 }
 
@@ -173,8 +186,16 @@ private val SampleSessionHasContent = Session(
     title = "세션 제목은 세션 제목 - 개요 있음",
     content = "세션에 대한 소개와 세션에서의 장단점과 세션을 실제로 사용한 사례와 세션 내용에 대한 QnA 진행",
     speakers = listOf(
-        Speaker(name = "스피커1", introduction = "", "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png"),
-        Speaker(name = "스피커2", introduction = "", "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png")
+        Speaker(
+            name = "스피커1",
+            introduction = "스피커1 에 대한 소개",
+            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+        ),
+        Speaker(
+            name = "스피커2",
+            introduction = "스피커2 에 대한 소개",
+            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+        )
     ),
     level = Level.ADVANCED,
     tags = listOf(Tag("Dev Environment")),
@@ -188,8 +209,16 @@ private val SampleSessionNoContent = Session(
     title = "세션 제목은 세션 제목 - 개요 없음",
     content = "",
     speakers = listOf(
-        Speaker(name = "스피커1", introduction = "", "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png"),
-        Speaker(name = "스피커2", introduction = "", "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png")
+        Speaker(
+            name = "스피커1",
+            introduction = "스피커1 에 대한 소개",
+            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+        ),
+        Speaker(
+            name = "스피커2",
+            introduction = "스피커2 에 대한 소개",
+            "https://raw.githubusercontent.com/droidknights/DroidKnights2023_App/main/storage/speaker/차영호.png",
+        )
     ),
     level = Level.ADVANCED,
     tags = listOf(Tag("Dev Environment")),

--- a/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
+++ b/feature/session/src/main/java/com/droidknights/app2023/feature/session/SessionDetailScreen.kt
@@ -129,7 +129,7 @@ private fun SessionDetailTitle(
         modifier = modifier.padding(end = 64.dp),
         text = title,
         style = KnightsTheme.typography.headlineMediumB,
-        color = MaterialTheme.colorScheme.onSurface,
+        color = MaterialTheme.colorScheme.onSecondaryContainer,
     )
 }
 
@@ -177,7 +177,7 @@ private fun SessionOverview(content: String) {
     Text(
         text = content,
         style = KnightsTheme.typography.titleSmallR140,
-        color = MaterialTheme.colorScheme.onSurface
+        color = MaterialTheme.colorScheme.onSecondaryContainer
     )
 }
 


### PR DESCRIPTION
## Issue
- close #232

## Overview (Required)
- 화면에 사용되는 글씨 색을 onSecondaryContainer로 통일하였습니다.
- 세션 상세 정보 화면에 Speaker 정보를 추가하였습니다.
- 공통으로 사용하던 SessionChips를 제거하였습니다
-> 추후 PR에서 세션 목록화면의 SessionCard에 북마크 칩이 들어가는것을 고려하여,
분기를 태우거나 Composable 함수를 열어두는것보다 제거하는것이 더 낫다고 판단하였는데
잘못 판단했다 생각되신다면 의견 주시면 감사하겠습니다!
- 스펙상 스피커가 여러명인것 같은데 실제로는 한 명만 존재하고 디자인에 고려되어있지 않아서
여러명인 경우의 디자인을 고려하지 않고 작성하였습니다!

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/37904970/e1887ca0-1f50-460a-ab75-c8972113c6d7" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/37904970/549d449f-a7ed-4a98-825f-c89072668fff" width="300" />
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/37904970/f2482339-e21b-4395-805b-035fb24b9ff6" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/37904970/00f8fec9-b947-47d5-b402-8de4a407f917" width="300" />
