### PR TITLE
[Bug] 설정 화면에서 카드의 그림자가 가려지는 문제 해결

### DIFF
--- a/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/SettingScreen.kt
@@ -43,9 +43,9 @@ internal fun SettingScreen(
     val scrollState = rememberScrollState()
     Column(
         Modifier
+            .verticalScroll(scrollState)
             .padding(padding)
-            .padding(8.dp)
-            .verticalScroll(scrollState),
+            .padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         OpenSourceCard(


### PR DESCRIPTION
## Overview (Required)
설정 화면에서 modifier 적용 순서 차이로 카드의 elevation에 의한 shadow가 짤리고 있었는데, modifier의 순서를 바꿔 해결했습니다.

## Links
none

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/e50b763e-b363-4f6c-b88a-eb1a7e07954b" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/97a81eb0-2ad2-46c6-9d5a-5b86d8b0ed57" width="300" />
