### PR TITLE
[Bug] 다크 모드에서 navigation bar 배경색이 올바르게 나오도록 수정

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/theme/Theme.kt
@@ -86,6 +86,7 @@ fun KnightsTheme(
         SideEffect {
             val window = (view.context as Activity).window
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightNavigationBars = !darkTheme
         }
     }
 

--- a/core/designsystem/src/main/res/values/themes.xml
+++ b/core/designsystem/src/main/res/values/themes.xml
@@ -3,9 +3,9 @@
 
     <style name="Theme.DroidKnights2023" parent="Theme.AppCompat.DayNight.NoActionBar" />
 
-    <style name="Theme.DroidKnights2023.NoStatusBar">
+    <style name="Theme.DroidKnights2023.TransparentSystemBar">
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>

--- a/feature/main/src/main/AndroidManifest.xml
+++ b/feature/main/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:configChanges="uiMode"
-            android:theme="@style/Theme.DroidKnights2023.NoStatusBar">
+            android:theme="@style/Theme.DroidKnights2023.TransparentSystemBar">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## Overview (Required)
실기기(갤럭시 S20)에서 앱을 깔아 다크 모드로 변경을 하니 하단 NavigationBar의 색상이 반영되지 않는 것에서 문제를 포착했습니다. 

- KnightsTheme 및 theme 관련 파일에서  statusBar만 다크모드에 따른 처리가 되어있는 것을 확인하여 navigation에 대한 처리도 추가했습니다.
- 그 과정에서 `NoStatusBar` 라는 theme 이름을 `NoSystemBar`와 `TransparentSystemBar` 사이에서 고민하다가 후자를 택했는데 의견을 여쭤보고  싶습니다.
- 이 수정을 하고 나서 before & after를 찍다가 발견한 것인데 Pixel + swipe gesture + light mode일 때도 문제가 있었습니다. after 사진과 같이 함께 해결된 것을 확인할 수 있습니다.

## Links
- none

## Screenshot
### Emulator (Pixel 7 Pro)
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/7b5a9d7d-eb36-4a33-acfd-f3edbbf458d8" width="200" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/c0d39d33-30d0-49b2-aa99-72a56f08e9a2" width="200" />
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/aaed5f00-f497-47b7-b109-492f7691b580" width="200" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/b3f6532e-5c28-40e5-908a-39a950d04f49" width="200" />
---
### Real Device (Galaxy S20)
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/72f1be89-b01f-4588-b7dc-3362639ce085" width="200" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/0194cbbe-22e9-4f15-a6d6-b762c934991e" width="200" />
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/dcae6e7e-4733-4470-868b-ecff28792d62" width="200" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/7759511/7d47bc32-2ea3-49ec-9978-373b3f52bd00" width="200" />

