### PR TITLE
[Bug] 버튼 연타 시 중복 호출 이슈 수정

### DIFF
--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
@@ -2,6 +2,8 @@ package com.droidknights.app2023.core.designsystem.component
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +18,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,6 +58,11 @@ fun KnightsTopAppBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(containerColor)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {}
+                )
                 .then(modifier)
         ) {
             if (navigationType == TopAppBarNavigationType.Back) {

--- a/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
+++ b/core/designsystem/src/main/java/com/droidknights/app2023/core/designsystem/component/TopAppBar.kt
@@ -2,8 +2,6 @@ package com.droidknights.app2023.core.designsystem.component
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,11 +16,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -58,11 +56,7 @@ fun KnightsTopAppBar(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(containerColor)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = {}
-                )
+                .pointerInput(Unit) { /* no-op */ }
                 .then(modifier)
         ) {
             if (navigationType == TopAppBarNavigationType.Back) {

--- a/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainNavigator.kt
@@ -68,7 +68,7 @@ internal class MainNavigator(
         }
     }
 
-    fun isSameCurrentDestination(route: String) =
+    private fun isSameCurrentDestination(route: String) =
         navController.currentDestination?.route == route
 
     @Composable

--- a/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainNavigator.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.droidknights.app2023.feature.bookmark.navigation.navigateBookmark
 import com.droidknights.app2023.feature.contributor.navigation.navigateContributor
+import com.droidknights.app2023.feature.home.navigation.HomeRoute
 import com.droidknights.app2023.feature.home.navigation.navigateHome
 import com.droidknights.app2023.feature.session.navigation.navigateSession
 import com.droidknights.app2023.feature.session.navigation.navigateSessionDetail
@@ -60,6 +61,15 @@ internal class MainNavigator(
     fun popBackStack() {
         navController.popBackStack()
     }
+
+    fun popBackStackIfNotHome() {
+        if (!isSameCurrentDestination(HomeRoute.route)) {
+            popBackStack()
+        }
+    }
+
+    fun isSameCurrentDestination(route: String) =
+        navController.currentDestination?.route == route
 
     @Composable
     fun shouldShowBottomBar(): Boolean {

--- a/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
@@ -40,6 +40,7 @@ import com.droidknights.app2023.core.designsystem.theme.Neon01
 import com.droidknights.app2023.core.designsystem.theme.surfaceDim
 import com.droidknights.app2023.feature.bookmark.navigation.bookmarkNavGraph
 import com.droidknights.app2023.feature.contributor.navigation.contributorNavGraph
+import com.droidknights.app2023.feature.home.navigation.HomeRoute
 import com.droidknights.app2023.feature.home.navigation.homeNavGraph
 import com.droidknights.app2023.feature.session.navigation.sessionNavGraph
 import com.droidknights.app2023.feature.setting.navigation.settingNavGraph
@@ -95,12 +96,12 @@ internal fun MainScreen(
                     )
 
                     contributorNavGraph(
-                        onBackClick = { navigator.popBackStack() },
+                        onBackClick = navigator::popBackStackIfNotHome,
                         onShowErrorSnackBar = onShowErrorSnackBar
                     )
 
                     sessionNavGraph(
-                        onBackClick = { navigator.popBackStack() },
+                        onBackClick = navigator::popBackStackIfNotHome,
                         onSessionClick = { navigator.navigateSessionDetail(it.id) },
                         onShowErrorSnackBar = onShowErrorSnackBar
                     )

--- a/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/droidknights/app2023/feature/main/MainScreen.kt
@@ -40,7 +40,6 @@ import com.droidknights.app2023.core.designsystem.theme.Neon01
 import com.droidknights.app2023.core.designsystem.theme.surfaceDim
 import com.droidknights.app2023.feature.bookmark.navigation.bookmarkNavGraph
 import com.droidknights.app2023.feature.contributor.navigation.contributorNavGraph
-import com.droidknights.app2023.feature.home.navigation.HomeRoute
 import com.droidknights.app2023.feature.home.navigation.homeNavGraph
 import com.droidknights.app2023.feature.session.navigation.sessionNavGraph
 import com.droidknights.app2023.feature.setting.navigation.settingNavGraph


### PR DESCRIPTION
## Overview (Required)

컴포넌트를 연타할 때 발생하는 중복 호출 이슈를 수정하였습니다.

### ISSUE1 뒤로가기 버튼 중복 호출
  - TopAppBar의 뒤로가기(종료) 버튼을 연타하면 Home 화면을 넘어가 뒤로가는 경우가 발생합니다.
  - currentDestination이 Home이 아닌 경우에만 뒤로가도록 수정하였습니다.

### ISSUE2 화면 중복 이동
   - 홈 화면에서 session 이동 카드를 TopAppBar 영역에 위치한 후 연타하면 화면이 계속 넘어갑니다.
   - navigate 시 이동할 destination과 currentDestination이 같지 않은 경우에만 이동하도록 함수를 구현하려하였으나
     - contributor 화면에서 AppBar 영역을 터치하여도 투과되어 뒤에 있는 카드가 클릭 되기에
     - TopAppBar에 빈 clickable을 제공하여 클릭 이벤트가 투과하는 것을 방지하였습니다.

## Screenshot
### ISSUE1 뒤로가기 버튼 중복 호출
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/4679634/bb9e62a2-2d94-4867-aa5e-b4875fa9535e" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/4679634/34d4cdbc-2688-4a4e-aa18-c7e00bfcb3aa" width="300" />

### ISSUE2 화면 중복 이동
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/4679634/4cc54592-2e49-4aca-8942-6058f9d18fcc" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/4679634/04874b67-de20-4cfe-a820-b9cebec7567e" width="300" />