### PR TITLE
[Bug] 오픈소스 라이센스 카드 클릭 시 카드 영역 밖으로 리플 효과 나타나지 않도록 수정

### DIFF
--- a/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/opensource/OpenSourceCard.kt
+++ b/feature/setting/src/main/java/com/droidknights/app2023/feature/setting/opensource/OpenSourceCard.kt
@@ -3,7 +3,6 @@ package com.droidknights.app2023.feature.setting.opensource
 import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -31,10 +30,10 @@ internal fun OpenSourceCard(
 
     KnightsCard(
         color = Graphite,
-        modifier = modifier
-            .clickable {
-                context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
-            },
+        modifier = modifier,
+        onClick = {
+            context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
+        }
     ) {
         Column {
             Text(


### PR DESCRIPTION
## Overview (Required)
- 오픈소스 라이센스 카드 컴포넌트의 modifier.clickable을 통해 OssLicensesMenuActivity로  이동하고 있어 아래의 사진과 같이 카드 영역 밖으로 ripple 효과가 생기고 있어, KnightsCard의 onClick 람다로  OssLicensesMenuActivity로 이동하도록 수정하였습니다.

## Links
none

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/droidknights/DroidKnights2023_App/assets/76798309/d2385432-4725-4e2a-9735-ca03b7105a07" width="300" /> | <img src="https://github.com/droidknights/DroidKnights2023_App/assets/76798309/ecb31cd4-67a4-4dd3-bb00-9a025b162a5e" width="300" />
