### PR TITLE
[feature/#246] bookmarkItems의 타입을 ImmutableList로 변경

### DIFF
--- a/feature/bookmark/build.gradle.kts
+++ b/feature/bookmark/build.gradle.kts
@@ -9,4 +9,5 @@ android {
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.kotlinx.immutable)
 }

--- a/feature/bookmark/src/main/java/com/droidknights/app2023/feature/bookmark/BookmarkScreen.kt
+++ b/feature/bookmark/src/main/java/com/droidknights/app2023/feature/bookmark/BookmarkScreen.kt
@@ -32,6 +32,8 @@ import com.droidknights.app2023.core.designsystem.theme.KnightsTheme
 import com.droidknights.app2023.core.designsystem.theme.PaleGray
 import com.droidknights.app2023.core.designsystem.theme.Purple01
 import com.droidknights.app2023.core.designsystem.theme.surfaceDim
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.collectLatest
 
 @Composable
@@ -67,7 +69,7 @@ private fun BookmarkContent(
         BookmarkUiState.Loading -> BookmarkLoading()
         is BookmarkUiState.Success -> BookmarkScreen(
             isEditMode = uiState.isEditButtonSelected,
-            bookmarkItems = uiState.bookmarks,
+            bookmarkItems = uiState.bookmarks.toImmutableList(),
             onClickEditButton = onClickEditButton
         )
     }
@@ -83,7 +85,7 @@ private fun BookmarkLoading() {
 @Composable
 private fun BookmarkScreen(
     isEditMode: Boolean,
-    bookmarkItems: List<BookmarkItemUiState>,
+    bookmarkItems: ImmutableList<BookmarkItemUiState>,
     onClickEditButton: () -> Unit,
     listContentBottomPadding: Dp = 72.dp
 ) {


### PR DESCRIPTION
## Issue
- close #246 

## Overview (Required)
- 관련 이슈 #222 
- 불필요하게 리컴포지션 될 수 있는 List 함수 패러미터를 ImmutableList로 변경한다

