### PR TITLE
Github Release로 APK Publish

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -35,9 +35,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: release-artifacts
-          paths: |
-            app/build/outputs/apk/release/
-            app/build/outputs/bundle/release/
+          path: app/build/outputs/apk/release/
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,48 @@
+name: Publish Android APK
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: 17
+
+      - name: Build Release APK
+        run: ./gradlew :app:assembleRelease
+
+      - name: Upload Release Build to Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-artifacts
+          paths: |
+            app/build/outputs/apk/release/
+            app/build/outputs/bundle/release/
+
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          prerelease: true
+          files: |
+            app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -41,6 +41,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
-          prerelease: true
           files: |
             app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -35,11 +35,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: release-artifacts
-          path: app/build/outputs/apk/release/
+          path: release/
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true
           files: |
-            app/build/outputs/apk/release/app-release.apk
+            release/app-release.apk


### PR DESCRIPTION
## Issue
- close #255 

## Overview (Required)
- 안드로이드 APK를 빌드하여 Release를 생성하는 워크플로우를 생성합니다.
  - Github Tag가 푸시되면 트리거됩니다.
  - `app-release.apk` 아티펙트 하나만 Release에 포함시킵니다.
- Release 내용은 기본 메시지로 설정했습니다. (changelog)

## Links
- Forked Repository에서 Release 생성 테스트 완료했습니다.
- https://github.com/wisemuji/DroidKnights2023_App/releases/tag/v1.0.1

<img width="370" alt="image" src="https://github.com/droidknights/DroidKnights2023_App/assets/32327475/d8fad1fe-576f-4dd5-80ea-8e1d1a817faa">
